### PR TITLE
2部〜8部までの名言生成画面を作成

### DIFF
--- a/FamousQuoteGeneratorForJojoApp/AppDelegate.swift
+++ b/FamousQuoteGeneratorForJojoApp/AppDelegate.swift
@@ -9,28 +9,29 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
+    
+    
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // アプリ全体のナビゲーションバーの戻るボタンの色を黒にする
+        UINavigationBar.appearance().tintColor = UIColor.black
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
+    
+    
 }
 

--- a/FamousQuoteGeneratorForJojoApp/FavoriteViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/FavoriteViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// お気に入り画面
 class FavoriteViewController: UIViewController {
 
     override func viewDidLoad() {

--- a/FamousQuoteGeneratorForJojoApp/Home/HomeCollectionViewCell.swift
+++ b/FamousQuoteGeneratorForJojoApp/Home/HomeCollectionViewCell.swift
@@ -9,11 +9,13 @@ import UIKit
 
 class HomeCollectionViewCell: UICollectionViewCell {
     
-    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet private weak var imageView: UIImageView!
     
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
     }
-    
+    func configure(imageString: String) {
+        imageView.image = UIImage(named: imageString)
+    }
 }

--- a/FamousQuoteGeneratorForJojoApp/Home/HomeCollectionViewCell.swift
+++ b/FamousQuoteGeneratorForJojoApp/Home/HomeCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class HomeCollectionViewCell: UICollectionViewCell {
     
-    @IBOutlet private weak var imageView: UIImageView!
+    @IBOutlet weak var imageView: UIImageView!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/FamousQuoteGeneratorForJojoApp/Home/HomeCollectionViewCell.swift
+++ b/FamousQuoteGeneratorForJojoApp/Home/HomeCollectionViewCell.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 class HomeCollectionViewCell: UICollectionViewCell {
-
-    @IBOutlet weak var imageView: UIImageView!
+    
+    @IBOutlet private weak var imageView: UIImageView!
     
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
     }
-
+    
 }

--- a/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
@@ -78,11 +78,6 @@ extension HomeViewController: UICollectionViewDelegate {
         default:
             break
         }
-        
-        // UICollectionViewの戻るボタンの色を変更する
-        if let navController = navigationController {
-            navController.navigationBar.tintColor = UIColor.black
-        }
     }
 }
 

--- a/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
@@ -12,12 +12,12 @@ class HomeViewController: UIViewController {
     
     // MARK: - Properties
     
-    let dataArray = ["jojo_1", "jojo_2", "jojo_3","jojo_4",
-                     "jojo_5", "jojo_6", "jojo_7", "jojo_8", "favorite"]
+    private let dataArray = ["jojo_1", "jojo_2", "jojo_3","jojo_4",
+                             "jojo_5", "jojo_6", "jojo_7", "jojo_8", "favorite"]
     
     // MARK: - IBOutlets
     
-    @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet private weak var collectionView: UICollectionView!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,7 +29,7 @@ class HomeViewController: UIViewController {
     
     // MARK: - Other Methods
     
-    func configureCollectionView() {
+    private func configureCollectionView() {
         // データソースを適用します
         collectionView.dataSource = self
         // デリゲートを適用します
@@ -50,31 +50,31 @@ extension HomeViewController: UICollectionViewDelegate {
         switch indexPath.row {
         case 0:
             let quote1VC = Quote1ViewController()
-                    navigationController?.pushViewController(quote1VC, animated: true)
+            navigationController?.pushViewController(quote1VC, animated: true)
         case 1:
             let quote2VC = Quote2ViewController()
-                    navigationController?.pushViewController(quote2VC, animated: true)
+            navigationController?.pushViewController(quote2VC, animated: true)
         case 2:
             let quote3VC = Quote3ViewController()
-                    navigationController?.pushViewController(quote3VC, animated: true)
+            navigationController?.pushViewController(quote3VC, animated: true)
         case 3:
             let quote4VC = Quote4ViewController()
-                    navigationController?.pushViewController(quote4VC, animated: true)
+            navigationController?.pushViewController(quote4VC, animated: true)
         case 4:
             let quote5VC = Quote5ViewController()
-                    navigationController?.pushViewController(quote5VC, animated: true)
+            navigationController?.pushViewController(quote5VC, animated: true)
         case 5:
             let quote6VC = Quote6ViewController()
-                    navigationController?.pushViewController(quote6VC, animated: true)
+            navigationController?.pushViewController(quote6VC, animated: true)
         case 6:
             let quote7VC = Quote7ViewController()
-                    navigationController?.pushViewController(quote7VC, animated: true)
+            navigationController?.pushViewController(quote7VC, animated: true)
         case 7:
             let quote8VC = Quote8ViewController()
-                    navigationController?.pushViewController(quote8VC, animated: true)
+            navigationController?.pushViewController(quote8VC, animated: true)
         case 8:
             let favoriteVC = FavoriteViewController()
-                    navigationController?.pushViewController(favoriteVC, animated: true)
+            navigationController?.pushViewController(favoriteVC, animated: true)
         default:
             break
         }
@@ -120,6 +120,6 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-         return 10.0 // 行間
+        return 10.0 // 行間
     }
 }

--- a/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
@@ -95,7 +95,7 @@ extension HomeViewController: UICollectionViewDataSource {
                         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell",
                                                       for: indexPath)as! HomeCollectionViewCell
-        cell.imageView.image = UIImage(named: dataArray[indexPath.item])
+        cell.configure(imageString: dataArray[indexPath.item])
         return cell
     }
 }

--- a/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Home/HomeViewController.swift
@@ -78,6 +78,11 @@ extension HomeViewController: UICollectionViewDelegate {
         default:
             break
         }
+        
+        // UICollectionViewの戻るボタンの色を変更する
+        if let navController = navigationController {
+            navController.navigationBar.tintColor = UIColor.black
+        }
     }
 }
 

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 1部名言生成画面
 class Quote1ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
@@ -12,9 +12,9 @@ class Quote1ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote1ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote1.randomElement() {
             quoteLabel.text = randomQuote.quote
@@ -43,7 +43,7 @@ class Quote1ViewController: UIViewController {
     // MARK: - Other Methods
     
     /// UIViewにグラデーションを追加する関数
-    func configureGradientView(view: UIView) {
+    private func configureGradientView(view: UIView) {
         let color1 = UIColor(hex: "#08CF79")
         let color2 = UIColor(hex: "#000000")
         let gradientLayer = CAGradientLayer()

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
@@ -9,8 +9,6 @@ import UIKit
 
 class Quote1ViewController: UIViewController {
     
-    // MARK: - Properties
-    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -45,7 +43,7 @@ class Quote1ViewController: UIViewController {
     // MARK: - Other Methods
     
     /// UIViewにグラデーションを追加する関数
-    private func configureGradientView(view: UIView) {
+    func configureGradientView(view: UIView) {
         let color1 = UIColor(hex: "#08CF79")
         let color2 = UIColor(hex: "#000000")
         let gradientLayer = CAGradientLayer()

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.xib
@@ -21,12 +21,12 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1部 ファントムブラッド" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fzI-Hy-rRf">
-                    <rect key="frame" x="46" y="64" width="301" height="103"/>
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="103" id="ZXB-a5-aSi"/>
-                        <constraint firstAttribute="width" constant="301" id="jAZ-2N-crO"/>
+                        <constraint firstAttribute="width" constant="373" id="lRf-kP-CyL"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
@@ -107,13 +107,13 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fzI-Hy-rRf" secondAttribute="trailing" constant="46" id="0js-vq-6we"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="fzI-Hy-rRf" secondAttribute="trailing" constant="10" id="0js-vq-6we"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Edd-Z9-x2Y" secondAttribute="trailing" constant="157" id="0lF-nQ-aCM"/>
                 <constraint firstItem="lri-np-bns" firstAttribute="top" secondItem="Edd-Z9-x2Y" secondAttribute="bottom" constant="30" id="3xe-UL-vGA"/>
                 <constraint firstItem="eff-Tb-GY2" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="HuC-bn-Vhj"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="lri-np-bns" secondAttribute="trailing" constant="112" id="QXV-iv-M9b"/>
                 <constraint firstItem="lri-np-bns" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="111" id="WvE-sH-nhq"/>
-                <constraint firstItem="fzI-Hy-rRf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="46" id="fcv-L5-YU4"/>
+                <constraint firstItem="fzI-Hy-rRf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="fcv-L5-YU4"/>
                 <constraint firstItem="eff-Tb-GY2" firstAttribute="top" secondItem="fzI-Hy-rRf" secondAttribute="bottom" constant="30" id="i78-eo-JfB"/>
                 <constraint firstItem="fzI-Hy-rRf" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="5" id="rQZ-Cy-VMp"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="eff-Tb-GY2" secondAttribute="trailing" constant="10" id="uJe-rk-Xz2"/>

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 2部名言生成画面
 class Quote2ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
@@ -12,9 +12,9 @@ class Quote2ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote2ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote2.randomElement() {
             quoteLabel.text = randomQuote.quote
@@ -43,7 +43,7 @@ class Quote2ViewController: UIViewController {
     // MARK: - Other Methods
     
     /// UIViewにグラデーションを追加する関数
-    func configureGradientView(view: UIView) {
+    private func configureGradientView(view: UIView) {
         let color1 = UIColor(hex: "#57FF03")
         let color2 = UIColor(hex: "#000000")
         let gradientLayer = CAGradientLayer()

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
@@ -8,22 +8,52 @@
 import UIKit
 
 class Quote2ViewController: UIViewController {
-
+    
+    // MARK: - IBOutlets
+    
+    /// 名言を表示させるラベル
+    @IBOutlet weak var quoteLabel: UILabel!
+    /// キャラクター名を表示させるラベル
+    @IBOutlet weak var characterLabel: UILabel!
+    
+    // MARK: - View Life-Cycle Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        if QuotesData.quote2.first != nil {
+            quoteLabel.text = "名言生成ッ!!をタップ"
+            characterLabel.text = ""}
+        configureGradientView(view: self.view)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: - IBActions
+    
+    @IBAction func favoriteButton(_ sender: Any) {
     }
-    */
-
+    
+    @IBAction func generateButton(_ sender: Any) {
+        //ランダムに名言を設定
+        if let randomQuote = QuotesData.quote2.randomElement() {
+            quoteLabel.text = randomQuote.quote
+            characterLabel.text = randomQuote.characterName
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// UIViewにグラデーションを追加する関数
+    func configureGradientView(view: UIView) {
+        let color1 = UIColor(hex: "#57FF03")
+        let color2 = UIColor(hex: "#000000")
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        gradientLayer.colors = [color1.cgColor, color2.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
 }
+
+

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.xib
@@ -4,21 +4,132 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Quote2ViewController" customModule="FamousQuoteGeneratorForJojoApp" customModuleProvider="target">
             <connections>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="characterLabel" destination="Oks-wf-vZF" id="BX4-O2-vOY"/>
+                <outlet property="quoteLabel" destination="cp0-Rz-vts" id="QSE-z5-nIQ"/>
+                <outlet property="view" destination="NRK-b6-znJ" id="y8q-6S-WH0"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="NRK-b6-znJ">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" red="0.4379573402709136" green="0.86078912019729614" blue="0.11308595398416053" alpha="0.73368693977002275" colorSpace="custom" customColorSpace="displayP3"/>
-            <point key="canvasLocation" x="18" y="21"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2部 戦闘潮流" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcw-Uf-VMQ">
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="103" id="gJS-a3-lgH"/>
+                        <constraint firstAttribute="width" constant="373" id="hUo-Bt-0SV"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view alpha="0.40000000596046448" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ce-62-ZfA">
+                    <rect key="frame" x="10" y="197" width="373" height="300"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名言" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cp0-Rz-vts">
+                            <rect key="frame" x="8" y="20" width="357" height="210"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="G7k-aL-Xb6"/>
+                                <constraint firstAttribute="height" constant="210" id="QcB-qu-1yP"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キャラクター名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oks-wf-vZF">
+                            <rect key="frame" x="8" y="238" width="357" height="54"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="54" id="81X-N1-m0L"/>
+                                <constraint firstAttribute="width" constant="357" id="Uw1-HS-t34"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="Oks-wf-vZF" secondAttribute="trailing" constant="8" id="803-5I-d5h"/>
+                        <constraint firstItem="Oks-wf-vZF" firstAttribute="leading" secondItem="4ce-62-ZfA" secondAttribute="leading" constant="8" id="BD1-Za-8i5"/>
+                        <constraint firstItem="Oks-wf-vZF" firstAttribute="top" secondItem="cp0-Rz-vts" secondAttribute="bottom" constant="8" symbolic="YES" id="PKV-yG-lO2"/>
+                        <constraint firstAttribute="trailing" secondItem="cp0-Rz-vts" secondAttribute="trailing" constant="8" id="R8f-2i-MYh"/>
+                        <constraint firstAttribute="height" constant="300" id="UX4-BU-caV"/>
+                        <constraint firstItem="cp0-Rz-vts" firstAttribute="top" secondItem="4ce-62-ZfA" secondAttribute="top" constant="20" symbolic="YES" id="V9Q-LP-evC"/>
+                        <constraint firstItem="cp0-Rz-vts" firstAttribute="leading" secondItem="4ce-62-ZfA" secondAttribute="leading" constant="8" id="i5M-fz-xOm"/>
+                        <constraint firstAttribute="width" constant="373" id="pUm-Nj-Gll"/>
+                        <constraint firstAttribute="bottom" secondItem="Oks-wf-vZF" secondAttribute="bottom" constant="8" id="sf3-v4-759"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="25"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6vW-zR-9nY">
+                    <rect key="frame" x="156" y="527" width="80" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="80" id="RlW-MU-97E"/>
+                        <constraint firstAttribute="height" constant="60" id="zFQ-fT-dpX"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
+                    <connections>
+                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="W2m-Az-Dwk"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="evj-nM-vOn">
+                    <rect key="frame" x="111" y="617" width="170" height="50"/>
+                    <color key="backgroundColor" red="0.20000000000000001" green="0.59999999999999998" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="qf0-uT-bdM"/>
+                        <constraint firstAttribute="width" constant="170" id="w0i-tG-6G2"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="名言生成ッ!!">
+                        <color key="baseForegroundColor" systemColor="labelColor"/>
+                    </buttonConfiguration>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="DFl-1A-dmW"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="l2B-76-8dZ"/>
+            <constraints>
+                <constraint firstItem="l2B-76-8dZ" firstAttribute="trailing" secondItem="evj-nM-vOn" secondAttribute="trailing" constant="112" id="9gI-ca-sym"/>
+                <constraint firstItem="6vW-zR-9nY" firstAttribute="leading" secondItem="l2B-76-8dZ" secondAttribute="leading" constant="156" id="BjZ-Kc-9Cv"/>
+                <constraint firstItem="l2B-76-8dZ" firstAttribute="trailing" secondItem="bcw-Uf-VMQ" secondAttribute="trailing" constant="10" id="C3i-lX-AaQ"/>
+                <constraint firstItem="l2B-76-8dZ" firstAttribute="trailing" secondItem="6vW-zR-9nY" secondAttribute="trailing" constant="157" id="DZt-an-9EX"/>
+                <constraint firstItem="l2B-76-8dZ" firstAttribute="trailing" secondItem="4ce-62-ZfA" secondAttribute="trailing" constant="10" id="G7R-O2-9Y5"/>
+                <constraint firstItem="evj-nM-vOn" firstAttribute="top" secondItem="6vW-zR-9nY" secondAttribute="bottom" constant="30" id="LLQ-jc-nOA"/>
+                <constraint firstItem="4ce-62-ZfA" firstAttribute="top" secondItem="bcw-Uf-VMQ" secondAttribute="bottom" constant="30" id="NOj-ce-r2x"/>
+                <constraint firstItem="bcw-Uf-VMQ" firstAttribute="leading" secondItem="l2B-76-8dZ" secondAttribute="leading" constant="10" id="OWn-yU-wHy"/>
+                <constraint firstItem="bcw-Uf-VMQ" firstAttribute="top" secondItem="l2B-76-8dZ" secondAttribute="top" constant="5" id="UAv-hl-CTV"/>
+                <constraint firstItem="6vW-zR-9nY" firstAttribute="top" secondItem="4ce-62-ZfA" secondAttribute="bottom" constant="30" id="jxe-3V-mlb"/>
+                <constraint firstItem="evj-nM-vOn" firstAttribute="leading" secondItem="l2B-76-8dZ" secondAttribute="leading" constant="111" id="v3s-Bd-2dy"/>
+                <constraint firstItem="4ce-62-ZfA" firstAttribute="leading" secondItem="l2B-76-8dZ" secondAttribute="leading" constant="10" id="ycr-fw-BuP"/>
+            </constraints>
+            <point key="canvasLocation" x="55.725190839694655" y="19.718309859154932"/>
         </view>
     </objects>
+    <resources>
+        <image name="favorite_button" width="56" height="54"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 3部名言生成画面
 class Quote3ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
@@ -12,9 +12,9 @@ class Quote3ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote3ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote3.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
@@ -8,22 +8,50 @@
 import UIKit
 
 class Quote3ViewController: UIViewController {
-
+    
+    // MARK: - IBOutlets
+    
+    /// 名言を表示させるラベル
+    @IBOutlet weak var quoteLabel: UILabel!
+    /// キャラクター名を表示させるラベル
+    @IBOutlet weak var characterLabel: UILabel!
+    
+    // MARK: - View Life-Cycle Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        if QuotesData.quote3.first != nil {
+            quoteLabel.text = "名言生成ッ!!をタップ"
+            characterLabel.text = ""}
+        configureGradientView(view: self.view)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: - IBActions
+    
+    @IBAction func favoriteButton(_ sender: Any) {
     }
-    */
-
+    
+    @IBAction func generateButton(_ sender: Any) {
+        //ランダムに名言を設定
+        if let randomQuote = QuotesData.quote3.randomElement() {
+            quoteLabel.text = randomQuote.quote
+            characterLabel.text = randomQuote.characterName
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// UIViewにグラデーションを追加する関数
+    private func configureGradientView(view: UIView) {
+        let color1 = UIColor(hex: "#0080FF")
+        let color2 = UIColor(hex: "#000000")
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        gradientLayer.colors = [color1.cgColor, color2.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
 }

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.xib
@@ -10,21 +10,126 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Quote3ViewController" customModule="FamousQuoteGeneratorForJojoApp" customModuleProvider="target">
             <connections>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="characterLabel" destination="qS3-6p-Xkv" id="uDP-gX-oUf"/>
+                <outlet property="quoteLabel" destination="kEF-A6-M8x" id="N8C-g8-5Af"/>
+                <outlet property="view" destination="fmP-nj-uQ1" id="SA1-eK-hf0"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="fmP-nj-uQ1">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemBlueColor"/>
-            <point key="canvasLocation" x="56" y="20"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3部 スターダストクルセイダーズ" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cPc-KR-1cZ">
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="103" id="LsF-gF-zrw"/>
+                        <constraint firstAttribute="width" constant="373" id="ycU-xm-mVW"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view alpha="0.40000000596046448" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SYp-gs-nTR">
+                    <rect key="frame" x="10" y="197" width="373" height="300"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名言" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kEF-A6-M8x">
+                            <rect key="frame" x="8" y="20" width="357" height="210"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="WoF-Kz-ZO0"/>
+                                <constraint firstAttribute="height" constant="210" id="jMm-EY-aJy"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キャラクター名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qS3-6p-Xkv">
+                            <rect key="frame" x="8" y="238" width="357" height="54"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="gCp-0J-97S"/>
+                                <constraint firstAttribute="height" constant="54" id="obz-0j-qsW"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="qS3-6p-Xkv" secondAttribute="bottom" constant="8" id="0fm-hv-lqZ"/>
+                        <constraint firstItem="qS3-6p-Xkv" firstAttribute="leading" secondItem="SYp-gs-nTR" secondAttribute="leading" constant="8" id="2WA-4P-XIi"/>
+                        <constraint firstAttribute="trailing" secondItem="qS3-6p-Xkv" secondAttribute="trailing" constant="8" id="EnA-40-mUK"/>
+                        <constraint firstAttribute="width" constant="373" id="Faa-bO-ifK"/>
+                        <constraint firstAttribute="trailing" secondItem="kEF-A6-M8x" secondAttribute="trailing" constant="8" id="Swz-Ov-e8S"/>
+                        <constraint firstItem="qS3-6p-Xkv" firstAttribute="top" secondItem="kEF-A6-M8x" secondAttribute="bottom" constant="8" symbolic="YES" id="e4F-Uq-QMY"/>
+                        <constraint firstItem="kEF-A6-M8x" firstAttribute="leading" secondItem="SYp-gs-nTR" secondAttribute="leading" constant="8" id="flX-ei-XAx"/>
+                        <constraint firstAttribute="height" constant="300" id="n7w-Qx-ymx"/>
+                        <constraint firstItem="kEF-A6-M8x" firstAttribute="top" secondItem="SYp-gs-nTR" secondAttribute="top" constant="20" symbolic="YES" id="wke-rC-4P3"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="25"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="24p-Bl-8PX">
+                    <rect key="frame" x="156" y="527" width="80" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="80" id="141-cw-YGD"/>
+                        <constraint firstAttribute="height" constant="60" id="S2V-Ut-uH5"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
+                    <connections>
+                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="RbV-fZ-Rgb"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r99-Kg-blS">
+                    <rect key="frame" x="111" y="617" width="170" height="50"/>
+                    <color key="backgroundColor" red="0.20000000000000001" green="0.59999999999999998" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="4bj-A7-XTt"/>
+                        <constraint firstAttribute="width" constant="170" id="lSR-12-NR9"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="名言生成ッ!!">
+                        <color key="baseForegroundColor" systemColor="labelColor"/>
+                    </buttonConfiguration>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="hZD-4R-Ph4"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="UBt-hE-k4J"/>
+            <constraints>
+                <constraint firstItem="24p-Bl-8PX" firstAttribute="leading" secondItem="UBt-hE-k4J" secondAttribute="leading" constant="156" id="4YJ-S9-umT"/>
+                <constraint firstItem="SYp-gs-nTR" firstAttribute="top" secondItem="cPc-KR-1cZ" secondAttribute="bottom" constant="30" id="Bbg-xu-efw"/>
+                <constraint firstItem="UBt-hE-k4J" firstAttribute="trailing" secondItem="cPc-KR-1cZ" secondAttribute="trailing" constant="10" id="LhA-9p-eHr"/>
+                <constraint firstItem="r99-Kg-blS" firstAttribute="leading" secondItem="UBt-hE-k4J" secondAttribute="leading" constant="111" id="MNE-Ak-fuR"/>
+                <constraint firstItem="24p-Bl-8PX" firstAttribute="top" secondItem="SYp-gs-nTR" secondAttribute="bottom" constant="30" id="ShN-L5-Y0m"/>
+                <constraint firstItem="SYp-gs-nTR" firstAttribute="leading" secondItem="UBt-hE-k4J" secondAttribute="leading" constant="10" id="TbG-XO-jpC"/>
+                <constraint firstItem="cPc-KR-1cZ" firstAttribute="top" secondItem="UBt-hE-k4J" secondAttribute="top" constant="5" id="i2S-0m-5Z1"/>
+                <constraint firstItem="UBt-hE-k4J" firstAttribute="trailing" secondItem="24p-Bl-8PX" secondAttribute="trailing" constant="157" id="ipi-vq-4EF"/>
+                <constraint firstItem="cPc-KR-1cZ" firstAttribute="leading" secondItem="UBt-hE-k4J" secondAttribute="leading" constant="10" id="ja7-13-vrI"/>
+                <constraint firstItem="UBt-hE-k4J" firstAttribute="trailing" secondItem="r99-Kg-blS" secondAttribute="trailing" constant="112" id="mx0-8c-fOs"/>
+                <constraint firstItem="UBt-hE-k4J" firstAttribute="trailing" secondItem="SYp-gs-nTR" secondAttribute="trailing" constant="10" id="n1q-qY-Dkt"/>
+                <constraint firstItem="r99-Kg-blS" firstAttribute="top" secondItem="24p-Bl-8PX" secondAttribute="bottom" constant="30" id="pLd-5U-NQO"/>
+            </constraints>
+            <point key="canvasLocation" x="55.725190839694655" y="19.718309859154932"/>
         </view>
     </objects>
     <resources>
-        <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <image name="favorite_button" width="56" height="54"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 4部名言生成画面
 class Quote4ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
@@ -8,22 +8,50 @@
 import UIKit
 
 class Quote4ViewController: UIViewController {
-
+    
+    // MARK: - IBOutlets
+    
+    /// 名言を表示させるラベル
+    @IBOutlet weak var quoteLabel: UILabel!
+    /// キャラクター名を表示させるラベル
+    @IBOutlet weak var characterLabel: UILabel!
+    
+    // MARK: - View Life-Cycle Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        if QuotesData.quote4.first != nil {
+            quoteLabel.text = "名言生成ッ!!をタップ"
+            characterLabel.text = ""}
+        configureGradientView(view: self.view)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: - IBActions
+    
+    @IBAction func favoriteButton(_ sender: Any) {
     }
-    */
-
+    
+    @IBAction func generateButton(_ sender: Any) {
+        //ランダムに名言を設定
+        if let randomQuote = QuotesData.quote4.randomElement() {
+            quoteLabel.text = randomQuote.quote
+            characterLabel.text = randomQuote.characterName
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// UIViewにグラデーションを追加する関数
+    private func configureGradientView(view: UIView) {
+        let color1 = UIColor(hex: "#B266FF")
+        let color2 = UIColor(hex: "#000000")
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        gradientLayer.colors = [color1.cgColor, color2.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
 }

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
@@ -12,9 +12,9 @@ class Quote4ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote4ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote4.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.xib
@@ -10,21 +10,126 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Quote4ViewController" customModule="FamousQuoteGeneratorForJojoApp" customModuleProvider="target">
             <connections>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="characterLabel" destination="bvs-g0-RPq" id="C4X-Tk-6to"/>
+                <outlet property="quoteLabel" destination="Qta-gm-nCy" id="DLl-a3-rhr"/>
+                <outlet property="view" destination="Hkb-va-Q8T" id="gyR-UH-2Fj"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="Hkb-va-Q8T">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemIndigoColor"/>
-            <point key="canvasLocation" x="56" y="20"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4部 ダイアモンドは砕けない" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x7n-4v-Tm8">
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="373" id="GUz-sd-Pxz"/>
+                        <constraint firstAttribute="height" constant="103" id="Tr6-FK-z7U"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view alpha="0.40000000596046448" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jhN-lN-bg3">
+                    <rect key="frame" x="10" y="197" width="373" height="300"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名言" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qta-gm-nCy">
+                            <rect key="frame" x="8" y="20" width="357" height="210"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="7Ro-qI-y0H"/>
+                                <constraint firstAttribute="height" constant="210" id="xZL-sV-01Z"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キャラクター名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bvs-g0-RPq">
+                            <rect key="frame" x="8" y="238" width="357" height="54"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="54" id="A7N-Li-0jk"/>
+                                <constraint firstAttribute="width" constant="357" id="bLv-po-Uul"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="bvs-g0-RPq" secondAttribute="trailing" constant="8" id="HIN-uF-WM6"/>
+                        <constraint firstItem="Qta-gm-nCy" firstAttribute="top" secondItem="jhN-lN-bg3" secondAttribute="top" constant="20" symbolic="YES" id="HQO-9D-0Hv"/>
+                        <constraint firstAttribute="height" constant="300" id="P65-NM-0pe"/>
+                        <constraint firstItem="bvs-g0-RPq" firstAttribute="top" secondItem="Qta-gm-nCy" secondAttribute="bottom" constant="8" symbolic="YES" id="VgD-PL-Hz2"/>
+                        <constraint firstAttribute="bottom" secondItem="bvs-g0-RPq" secondAttribute="bottom" constant="8" id="Z74-LR-V6S"/>
+                        <constraint firstAttribute="trailing" secondItem="Qta-gm-nCy" secondAttribute="trailing" constant="8" id="gwH-6E-evO"/>
+                        <constraint firstItem="Qta-gm-nCy" firstAttribute="leading" secondItem="jhN-lN-bg3" secondAttribute="leading" constant="8" id="v8B-jf-3dx"/>
+                        <constraint firstItem="bvs-g0-RPq" firstAttribute="leading" secondItem="jhN-lN-bg3" secondAttribute="leading" constant="8" id="xai-eZ-NmU"/>
+                        <constraint firstAttribute="width" constant="373" id="xq5-WP-YCd"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="25"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IpG-Bc-0Ch">
+                    <rect key="frame" x="156" y="527" width="80" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="60" id="OQr-6o-oGM"/>
+                        <constraint firstAttribute="width" constant="80" id="aLH-qs-Nf5"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
+                    <connections>
+                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="UBY-J0-xYz"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M86-dW-hKz">
+                    <rect key="frame" x="111" y="617" width="170" height="50"/>
+                    <color key="backgroundColor" red="0.20000000000000001" green="0.59999999999999998" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="170" id="8iv-Zk-Vbo"/>
+                        <constraint firstAttribute="height" constant="50" id="OVH-x2-Ube"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="名言生成ッ!!">
+                        <color key="baseForegroundColor" systemColor="labelColor"/>
+                    </buttonConfiguration>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="2Je-9I-at8"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="gMV-0s-RDc"/>
+            <constraints>
+                <constraint firstItem="x7n-4v-Tm8" firstAttribute="top" secondItem="gMV-0s-RDc" secondAttribute="top" constant="5" id="35X-xZ-C0q"/>
+                <constraint firstItem="gMV-0s-RDc" firstAttribute="trailing" secondItem="jhN-lN-bg3" secondAttribute="trailing" constant="10" id="OOF-BS-DMG"/>
+                <constraint firstItem="M86-dW-hKz" firstAttribute="top" secondItem="IpG-Bc-0Ch" secondAttribute="bottom" constant="30" id="Pya-9Y-VU3"/>
+                <constraint firstItem="gMV-0s-RDc" firstAttribute="trailing" secondItem="M86-dW-hKz" secondAttribute="trailing" constant="112" id="Xur-xQ-qot"/>
+                <constraint firstItem="gMV-0s-RDc" firstAttribute="trailing" secondItem="x7n-4v-Tm8" secondAttribute="trailing" constant="10" id="aIE-ym-6KS"/>
+                <constraint firstItem="IpG-Bc-0Ch" firstAttribute="leading" secondItem="gMV-0s-RDc" secondAttribute="leading" constant="156" id="gNz-N1-5ki"/>
+                <constraint firstItem="IpG-Bc-0Ch" firstAttribute="top" secondItem="jhN-lN-bg3" secondAttribute="bottom" constant="30" id="jsa-qr-zBf"/>
+                <constraint firstItem="M86-dW-hKz" firstAttribute="leading" secondItem="gMV-0s-RDc" secondAttribute="leading" constant="111" id="kyH-hy-LDU"/>
+                <constraint firstItem="jhN-lN-bg3" firstAttribute="leading" secondItem="gMV-0s-RDc" secondAttribute="leading" constant="10" id="naK-Yp-sgh"/>
+                <constraint firstItem="gMV-0s-RDc" firstAttribute="trailing" secondItem="IpG-Bc-0Ch" secondAttribute="trailing" constant="157" id="uPP-xM-pne"/>
+                <constraint firstItem="x7n-4v-Tm8" firstAttribute="leading" secondItem="gMV-0s-RDc" secondAttribute="leading" constant="10" id="xg2-UK-e5z"/>
+                <constraint firstItem="jhN-lN-bg3" firstAttribute="top" secondItem="x7n-4v-Tm8" secondAttribute="bottom" constant="30" id="zKj-Sr-ruW"/>
+            </constraints>
+            <point key="canvasLocation" x="55.725190839694655" y="19.718309859154932"/>
         </view>
     </objects>
     <resources>
-        <systemColor name="systemIndigoColor">
-            <color red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <image name="favorite_button" width="56" height="54"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
@@ -8,22 +8,50 @@
 import UIKit
 
 class Quote5ViewController: UIViewController {
-
+    
+    // MARK: - IBOutlets
+    
+    /// 名言を表示させるラベル
+    @IBOutlet weak var quoteLabel: UILabel!
+    /// キャラクター名を表示させるラベル
+    @IBOutlet weak var characterLabel: UILabel!
+    
+    // MARK: - View Life-Cycle Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        if QuotesData.quote5.first != nil {
+            quoteLabel.text = "名言生成ッ!!をタップ"
+            characterLabel.text = ""}
+        configureGradientView(view: self.view)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: - IBActions
+    
+    @IBAction func favoriteButton(_ sender: Any) {
     }
-    */
-
+    
+    @IBAction func generateButton(_ sender: Any) {
+        //ランダムに名言を設定
+        if let randomQuote = QuotesData.quote5.randomElement() {
+            quoteLabel.text = randomQuote.quote
+            characterLabel.text = randomQuote.characterName
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// UIViewにグラデーションを追加する関数
+    private func configureGradientView(view: UIView) {
+        let color1 = UIColor(hex: "#FFFF99")
+        let color2 = UIColor(hex: "#000000")
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        gradientLayer.colors = [color1.cgColor, color2.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
 }

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 5部名言生成画面
 class Quote5ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
@@ -12,9 +12,9 @@ class Quote5ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote5ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote5.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.xib
@@ -10,21 +10,126 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Quote5ViewController" customModule="FamousQuoteGeneratorForJojoApp" customModuleProvider="target">
             <connections>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="characterLabel" destination="YTT-yI-T4b" id="Zwh-bP-uBo"/>
+                <outlet property="quoteLabel" destination="qrL-w4-NRt" id="sdB-es-Krk"/>
+                <outlet property="view" destination="dc1-cg-Z1J" id="XCW-50-4ey"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="dc1-cg-Z1J">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemYellowColor"/>
-            <point key="canvasLocation" x="56" y="20"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5部 黄金の風" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PYH-VP-IQo">
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="103" id="tey-md-Gum"/>
+                        <constraint firstAttribute="width" constant="373" id="wnR-fZ-Qlf"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view alpha="0.40000000596046448" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KMM-ip-bY3">
+                    <rect key="frame" x="10" y="197" width="373" height="300"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名言" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qrL-w4-NRt">
+                            <rect key="frame" x="8" y="20" width="357" height="210"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="8xt-TZ-piy"/>
+                                <constraint firstAttribute="height" constant="210" id="SQb-Q1-mN8"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キャラクター名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YTT-yI-T4b">
+                            <rect key="frame" x="8" y="238" width="357" height="54"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="X0M-Cq-4dg"/>
+                                <constraint firstAttribute="height" constant="54" id="hwE-cJ-Pjm"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="qrL-w4-NRt" secondAttribute="trailing" constant="8" id="3or-4m-dU9"/>
+                        <constraint firstAttribute="trailing" secondItem="YTT-yI-T4b" secondAttribute="trailing" constant="8" id="6Bb-nC-ixu"/>
+                        <constraint firstAttribute="width" constant="373" id="Dc9-S2-BQQ"/>
+                        <constraint firstAttribute="height" constant="300" id="Oks-EV-tA8"/>
+                        <constraint firstItem="YTT-yI-T4b" firstAttribute="leading" secondItem="KMM-ip-bY3" secondAttribute="leading" constant="8" id="Rjc-Ns-KPm"/>
+                        <constraint firstAttribute="bottom" secondItem="YTT-yI-T4b" secondAttribute="bottom" constant="8" id="aIw-Na-Nyq"/>
+                        <constraint firstItem="YTT-yI-T4b" firstAttribute="top" secondItem="qrL-w4-NRt" secondAttribute="bottom" constant="8" symbolic="YES" id="cTf-3b-lMt"/>
+                        <constraint firstItem="qrL-w4-NRt" firstAttribute="leading" secondItem="KMM-ip-bY3" secondAttribute="leading" constant="8" id="pFx-qB-D1u"/>
+                        <constraint firstItem="qrL-w4-NRt" firstAttribute="top" secondItem="KMM-ip-bY3" secondAttribute="top" constant="20" symbolic="YES" id="zWB-nL-WCE"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="25"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uqg-4W-Hbg">
+                    <rect key="frame" x="156" y="527" width="80" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="60" id="DGy-8l-SJW"/>
+                        <constraint firstAttribute="width" constant="80" id="i6p-aY-sO2"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
+                    <connections>
+                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="2hn-bW-RYo"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Gc-S7-TEV">
+                    <rect key="frame" x="111" y="617" width="170" height="50"/>
+                    <color key="backgroundColor" red="0.20000000000000001" green="0.59999999999999998" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="170" id="D6o-w5-csi"/>
+                        <constraint firstAttribute="height" constant="50" id="hCf-hH-jwB"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="名言生成ッ!!">
+                        <color key="baseForegroundColor" systemColor="labelColor"/>
+                    </buttonConfiguration>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="zPs-Yt-Tuj"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="luY-VA-f4w"/>
+            <constraints>
+                <constraint firstItem="luY-VA-f4w" firstAttribute="trailing" secondItem="4Gc-S7-TEV" secondAttribute="trailing" constant="112" id="42x-ed-btd"/>
+                <constraint firstItem="PYH-VP-IQo" firstAttribute="leading" secondItem="luY-VA-f4w" secondAttribute="leading" constant="10" id="BPb-6i-60g"/>
+                <constraint firstItem="PYH-VP-IQo" firstAttribute="top" secondItem="luY-VA-f4w" secondAttribute="top" constant="5" id="EXd-Lb-vu1"/>
+                <constraint firstItem="uqg-4W-Hbg" firstAttribute="top" secondItem="KMM-ip-bY3" secondAttribute="bottom" constant="30" id="GlR-db-B5c"/>
+                <constraint firstItem="luY-VA-f4w" firstAttribute="trailing" secondItem="uqg-4W-Hbg" secondAttribute="trailing" constant="157" id="OTk-qJ-fje"/>
+                <constraint firstItem="4Gc-S7-TEV" firstAttribute="top" secondItem="uqg-4W-Hbg" secondAttribute="bottom" constant="30" id="RFY-O0-imP"/>
+                <constraint firstItem="luY-VA-f4w" firstAttribute="trailing" secondItem="KMM-ip-bY3" secondAttribute="trailing" constant="10" id="UKs-av-DQT"/>
+                <constraint firstItem="KMM-ip-bY3" firstAttribute="leading" secondItem="luY-VA-f4w" secondAttribute="leading" constant="10" id="Wjm-HX-qiw"/>
+                <constraint firstItem="luY-VA-f4w" firstAttribute="trailing" secondItem="PYH-VP-IQo" secondAttribute="trailing" constant="10" id="ZkI-Hp-ihC"/>
+                <constraint firstItem="KMM-ip-bY3" firstAttribute="top" secondItem="PYH-VP-IQo" secondAttribute="bottom" constant="30" id="lCX-uf-m5U"/>
+                <constraint firstItem="uqg-4W-Hbg" firstAttribute="leading" secondItem="luY-VA-f4w" secondAttribute="leading" constant="156" id="lnf-1x-Xyd"/>
+                <constraint firstItem="4Gc-S7-TEV" firstAttribute="leading" secondItem="luY-VA-f4w" secondAttribute="leading" constant="111" id="sov-Bw-WIJ"/>
+            </constraints>
+            <point key="canvasLocation" x="55.725190839694655" y="19.718309859154932"/>
         </view>
     </objects>
     <resources>
-        <systemColor name="systemYellowColor">
-            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <image name="favorite_button" width="56" height="54"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
@@ -12,9 +12,9 @@ class Quote6ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote6ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote6.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 6部名言生成画面
 class Quote6ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
@@ -8,22 +8,50 @@
 import UIKit
 
 class Quote6ViewController: UIViewController {
-
+    
+    // MARK: - IBOutlets
+    
+    /// 名言を表示させるラベル
+    @IBOutlet weak var quoteLabel: UILabel!
+    /// キャラクター名を表示させるラベル
+    @IBOutlet weak var characterLabel: UILabel!
+    
+    // MARK: - View Life-Cycle Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        if QuotesData.quote6.first != nil {
+            quoteLabel.text = "名言生成ッ!!をタップ"
+            characterLabel.text = ""}
+        configureGradientView(view: self.view)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: - IBActions
+    
+    @IBAction func favoriteButton(_ sender: Any) {
     }
-    */
-
+    
+    @IBAction func generateButton(_ sender: Any) {
+        //ランダムに名言を設定
+        if let randomQuote = QuotesData.quote6.randomElement() {
+            quoteLabel.text = randomQuote.quote
+            characterLabel.text = randomQuote.characterName
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// UIViewにグラデーションを追加する関数
+    private func configureGradientView(view: UIView) {
+        let color1 = UIColor(hex: "#87EBFF")
+        let color2 = UIColor(hex: "#000000")
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        gradientLayer.colors = [color1.cgColor, color2.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
 }

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.xib
@@ -10,21 +10,126 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Quote6ViewController" customModule="FamousQuoteGeneratorForJojoApp" customModuleProvider="target">
             <connections>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="characterLabel" destination="R5T-i1-vtx" id="URs-RF-aWV"/>
+                <outlet property="quoteLabel" destination="s32-SQ-DpE" id="fBZ-BN-BqK"/>
+                <outlet property="view" destination="56P-A6-8Jh" id="eNq-xH-IDe"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="56P-A6-8Jh">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemMintColor"/>
-            <point key="canvasLocation" x="56" y="20"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="6部 ストーンオーシャン" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dKz-Ym-d5u">
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="373" id="bPL-o8-OyK"/>
+                        <constraint firstAttribute="height" constant="103" id="p8Q-wo-0Ky"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view alpha="0.40000000596046448" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="596-eD-ShA">
+                    <rect key="frame" x="10" y="197" width="373" height="300"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名言" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s32-SQ-DpE">
+                            <rect key="frame" x="8" y="20" width="357" height="210"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="BYu-US-Abz"/>
+                                <constraint firstAttribute="height" constant="210" id="Jrd-Eg-ixg"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キャラクター名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R5T-i1-vtx">
+                            <rect key="frame" x="8" y="238" width="357" height="54"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="Dey-ya-j3j"/>
+                                <constraint firstAttribute="height" constant="54" id="HDv-yd-gVA"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstItem="R5T-i1-vtx" firstAttribute="leading" secondItem="596-eD-ShA" secondAttribute="leading" constant="8" id="DnW-MH-MYh"/>
+                        <constraint firstItem="R5T-i1-vtx" firstAttribute="top" secondItem="s32-SQ-DpE" secondAttribute="bottom" constant="8" symbolic="YES" id="FDb-A0-1vk"/>
+                        <constraint firstAttribute="width" constant="373" id="FXj-60-E9w"/>
+                        <constraint firstItem="s32-SQ-DpE" firstAttribute="top" secondItem="596-eD-ShA" secondAttribute="top" constant="20" symbolic="YES" id="MYf-Dl-UYj"/>
+                        <constraint firstItem="s32-SQ-DpE" firstAttribute="leading" secondItem="596-eD-ShA" secondAttribute="leading" constant="8" id="aim-nW-GKD"/>
+                        <constraint firstAttribute="trailing" secondItem="s32-SQ-DpE" secondAttribute="trailing" constant="8" id="mBV-KB-H5b"/>
+                        <constraint firstAttribute="trailing" secondItem="R5T-i1-vtx" secondAttribute="trailing" constant="8" id="p9C-TT-7zW"/>
+                        <constraint firstAttribute="bottom" secondItem="R5T-i1-vtx" secondAttribute="bottom" constant="8" id="qC8-2L-bfo"/>
+                        <constraint firstAttribute="height" constant="300" id="rC3-ZD-KFG"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="25"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BWu-Dk-ug3">
+                    <rect key="frame" x="156" y="527" width="80" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="80" id="Zdg-5L-BXC"/>
+                        <constraint firstAttribute="height" constant="60" id="beu-Mt-Lcf"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
+                    <connections>
+                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="APN-0X-ys2"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sv9-aJ-lRr">
+                    <rect key="frame" x="111" y="617" width="170" height="50"/>
+                    <color key="backgroundColor" red="0.20000000000000001" green="0.59999999999999998" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="e4l-Oj-vqU"/>
+                        <constraint firstAttribute="width" constant="170" id="hgC-kf-OMT"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="名言生成ッ!!">
+                        <color key="baseForegroundColor" systemColor="labelColor"/>
+                    </buttonConfiguration>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="p1q-W5-KMQ"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="BNd-vI-rj2"/>
+            <constraints>
+                <constraint firstItem="BNd-vI-rj2" firstAttribute="trailing" secondItem="596-eD-ShA" secondAttribute="trailing" constant="10" id="0uR-JJ-Awb"/>
+                <constraint firstItem="dKz-Ym-d5u" firstAttribute="leading" secondItem="BNd-vI-rj2" secondAttribute="leading" constant="10" id="BJS-CD-6Wx"/>
+                <constraint firstItem="dKz-Ym-d5u" firstAttribute="top" secondItem="BNd-vI-rj2" secondAttribute="top" constant="5" id="KVa-O4-dRf"/>
+                <constraint firstItem="BWu-Dk-ug3" firstAttribute="top" secondItem="596-eD-ShA" secondAttribute="bottom" constant="30" id="WH6-tl-e94"/>
+                <constraint firstItem="Sv9-aJ-lRr" firstAttribute="top" secondItem="BWu-Dk-ug3" secondAttribute="bottom" constant="30" id="X9z-Wq-QPs"/>
+                <constraint firstItem="596-eD-ShA" firstAttribute="leading" secondItem="BNd-vI-rj2" secondAttribute="leading" constant="10" id="a4c-s5-43w"/>
+                <constraint firstItem="BNd-vI-rj2" firstAttribute="trailing" secondItem="Sv9-aJ-lRr" secondAttribute="trailing" constant="112" id="adq-a1-vEE"/>
+                <constraint firstItem="Sv9-aJ-lRr" firstAttribute="leading" secondItem="BNd-vI-rj2" secondAttribute="leading" constant="111" id="bB2-nB-fL6"/>
+                <constraint firstItem="BWu-Dk-ug3" firstAttribute="leading" secondItem="BNd-vI-rj2" secondAttribute="leading" constant="156" id="bEB-Sk-Ifd"/>
+                <constraint firstItem="596-eD-ShA" firstAttribute="top" secondItem="dKz-Ym-d5u" secondAttribute="bottom" constant="30" id="dbh-fM-ytB"/>
+                <constraint firstItem="BNd-vI-rj2" firstAttribute="trailing" secondItem="BWu-Dk-ug3" secondAttribute="trailing" constant="157" id="eWV-Q1-QSM"/>
+                <constraint firstItem="BNd-vI-rj2" firstAttribute="trailing" secondItem="dKz-Ym-d5u" secondAttribute="trailing" constant="10" id="pYI-Gs-Tme"/>
+            </constraints>
+            <point key="canvasLocation" x="55.725190839694655" y="19.718309859154932"/>
         </view>
     </objects>
     <resources>
-        <systemColor name="systemMintColor">
-            <color red="0.0" green="0.78039215689999997" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <image name="favorite_button" width="56" height="54"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
@@ -12,9 +12,9 @@ class Quote7ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote7ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote7.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 7部名言生成画面
 class Quote7ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
@@ -8,22 +8,50 @@
 import UIKit
 
 class Quote7ViewController: UIViewController {
-
+    
+    // MARK: - IBOutlets
+    
+    /// 名言を表示させるラベル
+    @IBOutlet weak var quoteLabel: UILabel!
+    /// キャラクター名を表示させるラベル
+    @IBOutlet weak var characterLabel: UILabel!
+    
+    // MARK: - View Life-Cycle Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        if QuotesData.quote7.first != nil {
+            quoteLabel.text = "名言生成ッ!!をタップ"
+            characterLabel.text = ""}
+        configureGradientView(view: self.view)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: - IBActions
+    
+    @IBAction func favoriteButton(_ sender: Any) {
     }
-    */
-
+    
+    @IBAction func generateButton(_ sender: Any) {
+        //ランダムに名言を設定
+        if let randomQuote = QuotesData.quote7.randomElement() {
+            quoteLabel.text = randomQuote.quote
+            characterLabel.text = randomQuote.characterName
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// UIViewにグラデーションを追加する関数
+    private func configureGradientView(view: UIView) {
+        let color1 = UIColor(hex: "#FFCC99")
+        let color2 = UIColor(hex: "#000000")
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        gradientLayer.colors = [color1.cgColor, color2.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
 }

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.xib
@@ -10,21 +10,126 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Quote7ViewController" customModule="FamousQuoteGeneratorForJojoApp" customModuleProvider="target">
             <connections>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="characterLabel" destination="Kcd-sA-gYa" id="p4d-zZ-EEP"/>
+                <outlet property="quoteLabel" destination="rdP-ac-plg" id="ELO-Wk-pxM"/>
+                <outlet property="view" destination="iqs-oW-W0Q" id="7J6-Jf-gLG"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="iqs-oW-W0Q">
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemOrangeColor"/>
-            <point key="canvasLocation" x="18" y="21"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="7部 スティール・ボール・ラン" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XDn-hv-qMi">
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="103" id="4Il-ni-VfN"/>
+                        <constraint firstAttribute="width" constant="373" id="HRB-or-9jV"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view alpha="0.40000000596046448" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L4E-9g-xBO">
+                    <rect key="frame" x="10" y="197" width="373" height="300"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名言" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rdP-ac-plg">
+                            <rect key="frame" x="8" y="20" width="357" height="210"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="9w8-bH-NNx"/>
+                                <constraint firstAttribute="height" constant="210" id="oLL-Hs-yFS"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キャラクター名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kcd-sA-gYa">
+                            <rect key="frame" x="8" y="238" width="357" height="54"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="54" id="CYt-BN-yjQ"/>
+                                <constraint firstAttribute="width" constant="357" id="jbo-xZ-Nsy"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="rdP-ac-plg" secondAttribute="trailing" constant="8" id="8Dd-Qa-QZZ"/>
+                        <constraint firstAttribute="trailing" secondItem="Kcd-sA-gYa" secondAttribute="trailing" constant="8" id="FiU-gd-iXF"/>
+                        <constraint firstAttribute="bottom" secondItem="Kcd-sA-gYa" secondAttribute="bottom" constant="8" id="J88-kM-oTS"/>
+                        <constraint firstItem="Kcd-sA-gYa" firstAttribute="top" secondItem="rdP-ac-plg" secondAttribute="bottom" constant="8" symbolic="YES" id="KaX-K6-s72"/>
+                        <constraint firstAttribute="width" constant="373" id="PDa-6B-IaB"/>
+                        <constraint firstItem="rdP-ac-plg" firstAttribute="leading" secondItem="L4E-9g-xBO" secondAttribute="leading" constant="8" id="XxT-cJ-U7x"/>
+                        <constraint firstAttribute="height" constant="300" id="mgY-G4-4PX"/>
+                        <constraint firstItem="Kcd-sA-gYa" firstAttribute="leading" secondItem="L4E-9g-xBO" secondAttribute="leading" constant="8" id="o5d-oO-kwB"/>
+                        <constraint firstItem="rdP-ac-plg" firstAttribute="top" secondItem="L4E-9g-xBO" secondAttribute="top" constant="20" symbolic="YES" id="vwl-7t-Xe1"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="25"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="23x-ir-EVe">
+                    <rect key="frame" x="156" y="527" width="80" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="80" id="FEO-UK-L3n"/>
+                        <constraint firstAttribute="height" constant="60" id="htP-MH-3aV"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
+                    <connections>
+                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="4js-9d-Qum"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="azN-ze-Gng">
+                    <rect key="frame" x="111" y="617" width="170" height="50"/>
+                    <color key="backgroundColor" red="0.20000000000000001" green="0.59999999999999998" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="170" id="Z7u-0e-e65"/>
+                        <constraint firstAttribute="height" constant="50" id="pNj-cC-l6h"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="名言生成ッ!!">
+                        <color key="baseForegroundColor" systemColor="labelColor"/>
+                    </buttonConfiguration>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="Cyd-qi-INO"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="qb6-z3-ZOo"/>
+            <constraints>
+                <constraint firstItem="qb6-z3-ZOo" firstAttribute="trailing" secondItem="23x-ir-EVe" secondAttribute="trailing" constant="157" id="0ON-nH-s7C"/>
+                <constraint firstItem="qb6-z3-ZOo" firstAttribute="trailing" secondItem="XDn-hv-qMi" secondAttribute="trailing" constant="10" id="5w2-D8-x6j"/>
+                <constraint firstItem="qb6-z3-ZOo" firstAttribute="trailing" secondItem="L4E-9g-xBO" secondAttribute="trailing" constant="10" id="7MB-LV-w6x"/>
+                <constraint firstItem="L4E-9g-xBO" firstAttribute="top" secondItem="XDn-hv-qMi" secondAttribute="bottom" constant="30" id="8FQ-s8-03t"/>
+                <constraint firstItem="qb6-z3-ZOo" firstAttribute="trailing" secondItem="azN-ze-Gng" secondAttribute="trailing" constant="112" id="9gd-0z-s8E"/>
+                <constraint firstItem="XDn-hv-qMi" firstAttribute="top" secondItem="qb6-z3-ZOo" secondAttribute="top" constant="5" id="A0n-4R-UxI"/>
+                <constraint firstItem="XDn-hv-qMi" firstAttribute="leading" secondItem="qb6-z3-ZOo" secondAttribute="leading" constant="10" id="GVA-xj-Dpu"/>
+                <constraint firstItem="23x-ir-EVe" firstAttribute="leading" secondItem="qb6-z3-ZOo" secondAttribute="leading" constant="156" id="JZz-cJ-Zjt"/>
+                <constraint firstItem="azN-ze-Gng" firstAttribute="leading" secondItem="qb6-z3-ZOo" secondAttribute="leading" constant="111" id="U6z-FZ-e5t"/>
+                <constraint firstItem="23x-ir-EVe" firstAttribute="top" secondItem="L4E-9g-xBO" secondAttribute="bottom" constant="30" id="XvI-8h-p0T"/>
+                <constraint firstItem="azN-ze-Gng" firstAttribute="top" secondItem="23x-ir-EVe" secondAttribute="bottom" constant="30" id="xrf-fi-mJH"/>
+                <constraint firstItem="L4E-9g-xBO" firstAttribute="leading" secondItem="qb6-z3-ZOo" secondAttribute="leading" constant="10" id="zWd-VC-T2E"/>
+            </constraints>
+            <point key="canvasLocation" x="55.725190839694655" y="19.718309859154932"/>
         </view>
     </objects>
     <resources>
-        <systemColor name="systemOrangeColor">
-            <color red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <image name="favorite_button" width="56" height="54"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
@@ -8,22 +8,50 @@
 import UIKit
 
 class Quote8ViewController: UIViewController {
-
+    
+    // MARK: - IBOutlets
+    
+    /// 名言を表示させるラベル
+    @IBOutlet weak var quoteLabel: UILabel!
+    /// キャラクター名を表示させるラベル
+    @IBOutlet weak var characterLabel: UILabel!
+    
+    // MARK: - View Life-Cycle Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        if QuotesData.quote8.first != nil {
+            quoteLabel.text = "名言生成ッ!!をタップ"
+            characterLabel.text = ""}
+        configureGradientView(view: self.view)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: - IBActions
+    
+    @IBAction func favoriteButton(_ sender: Any) {
     }
-    */
-
+    
+    @IBAction func generateButton(_ sender: Any) {
+        //ランダムに名言を設定
+        if let randomQuote = QuotesData.quote8.randomElement() {
+            quoteLabel.text = randomQuote.quote
+            characterLabel.text = randomQuote.characterName
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// UIViewにグラデーションを追加する関数
+    private func configureGradientView(view: UIView) {
+        let color1 = UIColor(hex: "#E6E6E6")
+        let color2 = UIColor(hex: "#000000")
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        gradientLayer.colors = [color1.cgColor, color2.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
 }

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 8部名言生成画面
 class Quote8ViewController: UIViewController {
     
     // MARK: - IBOutlets

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
@@ -12,9 +12,9 @@ class Quote8ViewController: UIViewController {
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
-    @IBOutlet weak var quoteLabel: UILabel!
+    @IBOutlet private weak var quoteLabel: UILabel!
     /// キャラクター名を表示させるラベル
-    @IBOutlet weak var characterLabel: UILabel!
+    @IBOutlet private weak var characterLabel: UILabel!
     
     // MARK: - View Life-Cycle Methods
     
@@ -29,10 +29,10 @@ class Quote8ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction func favoriteButton(_ sender: Any) {
+    @IBAction private func favoriteButton(_ sender: Any) {
     }
     
-    @IBAction func generateButton(_ sender: Any) {
+    @IBAction private func generateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote8.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.xib
@@ -10,21 +10,126 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Quote8ViewController" customModule="FamousQuoteGeneratorForJojoApp" customModuleProvider="target">
             <connections>
-                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="characterLabel" destination="wWp-hr-tdM" id="gXQ-u3-bSX"/>
+                <outlet property="quoteLabel" destination="17R-Qz-jKJ" id="Zq8-Ln-drh"/>
+                <outlet property="view" destination="1ZR-2l-ABg" id="FwF-vs-J9w"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="1ZR-2l-ABg">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemGray2Color"/>
-            <point key="canvasLocation" x="18" y="21"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8部 ジョジョリオン" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ygD-bl-3ti">
+                    <rect key="frame" x="10" y="64" width="373" height="103"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="373" id="boI-up-i5h"/>
+                        <constraint firstAttribute="height" constant="103" id="fyn-Vd-RV1"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view alpha="0.40000000596046448" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eCs-Z6-dTY">
+                    <rect key="frame" x="10" y="197" width="373" height="300"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="名言" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="17R-Qz-jKJ">
+                            <rect key="frame" x="8" y="20" width="357" height="210"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="210" id="Est-es-sSM"/>
+                                <constraint firstAttribute="width" constant="357" id="Pie-xa-TLU"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キャラクター名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wWp-hr-tdM">
+                            <rect key="frame" x="8" y="238" width="357" height="54"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="357" id="6x7-uN-ToO"/>
+                                <constraint firstAttribute="height" constant="54" id="aQV-1n-xuh"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="wWp-hr-tdM" secondAttribute="bottom" constant="8" id="58n-mE-unQ"/>
+                        <constraint firstAttribute="width" constant="373" id="BKl-nw-ilR"/>
+                        <constraint firstAttribute="trailing" secondItem="17R-Qz-jKJ" secondAttribute="trailing" constant="8" id="Paa-37-Y0n"/>
+                        <constraint firstItem="17R-Qz-jKJ" firstAttribute="leading" secondItem="eCs-Z6-dTY" secondAttribute="leading" constant="8" id="PnY-EY-Ku3"/>
+                        <constraint firstAttribute="height" constant="300" id="XQh-HE-z0d"/>
+                        <constraint firstItem="17R-Qz-jKJ" firstAttribute="top" secondItem="eCs-Z6-dTY" secondAttribute="top" constant="20" symbolic="YES" id="fnd-ie-1ai"/>
+                        <constraint firstItem="wWp-hr-tdM" firstAttribute="top" secondItem="17R-Qz-jKJ" secondAttribute="bottom" constant="8" symbolic="YES" id="hmQ-ZR-rT6"/>
+                        <constraint firstItem="wWp-hr-tdM" firstAttribute="leading" secondItem="eCs-Z6-dTY" secondAttribute="leading" constant="8" id="jOu-kV-CFY"/>
+                        <constraint firstAttribute="trailing" secondItem="wWp-hr-tdM" secondAttribute="trailing" constant="8" id="oEx-yH-Oaa"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="25"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PBc-qD-PeT">
+                    <rect key="frame" x="156" y="527" width="80" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="80" id="Vif-k9-Miq"/>
+                        <constraint firstAttribute="height" constant="60" id="sfw-Ca-4yO"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
+                    <connections>
+                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="uCt-qt-8aS"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MBB-Qq-Ie3">
+                    <rect key="frame" x="111" y="617" width="170" height="50"/>
+                    <color key="backgroundColor" red="0.20000000000000001" green="0.59999999999999998" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="170" id="QlA-Ej-vFH"/>
+                        <constraint firstAttribute="height" constant="50" id="psk-2L-NlU"/>
+                    </constraints>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain" title="名言生成ッ!!">
+                        <color key="baseForegroundColor" systemColor="labelColor"/>
+                    </buttonConfiguration>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="udO-wT-u45"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="RK1-UB-BWL"/>
+            <constraints>
+                <constraint firstItem="RK1-UB-BWL" firstAttribute="trailing" secondItem="MBB-Qq-Ie3" secondAttribute="trailing" constant="112" id="4pC-N4-BIZ"/>
+                <constraint firstItem="ygD-bl-3ti" firstAttribute="leading" secondItem="RK1-UB-BWL" secondAttribute="leading" constant="10" id="CBw-Vx-Hij"/>
+                <constraint firstItem="PBc-qD-PeT" firstAttribute="top" secondItem="eCs-Z6-dTY" secondAttribute="bottom" constant="30" id="DAN-AV-WZM"/>
+                <constraint firstItem="RK1-UB-BWL" firstAttribute="trailing" secondItem="PBc-qD-PeT" secondAttribute="trailing" constant="157" id="G5q-GE-hlQ"/>
+                <constraint firstItem="MBB-Qq-Ie3" firstAttribute="leading" secondItem="RK1-UB-BWL" secondAttribute="leading" constant="111" id="HdJ-HI-BxK"/>
+                <constraint firstItem="MBB-Qq-Ie3" firstAttribute="top" secondItem="PBc-qD-PeT" secondAttribute="bottom" constant="30" id="JaO-30-wNw"/>
+                <constraint firstItem="RK1-UB-BWL" firstAttribute="trailing" secondItem="ygD-bl-3ti" secondAttribute="trailing" constant="10" id="btm-pu-OYD"/>
+                <constraint firstItem="RK1-UB-BWL" firstAttribute="trailing" secondItem="eCs-Z6-dTY" secondAttribute="trailing" constant="10" id="dbv-BK-6ft"/>
+                <constraint firstItem="eCs-Z6-dTY" firstAttribute="top" secondItem="ygD-bl-3ti" secondAttribute="bottom" constant="30" id="gLk-cX-Sah"/>
+                <constraint firstItem="ygD-bl-3ti" firstAttribute="top" secondItem="RK1-UB-BWL" secondAttribute="top" constant="5" id="ocD-8m-2bc"/>
+                <constraint firstItem="PBc-qD-PeT" firstAttribute="leading" secondItem="RK1-UB-BWL" secondAttribute="leading" constant="156" id="zdD-yo-oNh"/>
+                <constraint firstItem="eCs-Z6-dTY" firstAttribute="leading" secondItem="RK1-UB-BWL" secondAttribute="leading" constant="10" id="zhz-D5-nB8"/>
+            </constraints>
+            <point key="canvasLocation" x="55.725190839694655" y="19.718309859154932"/>
         </view>
     </objects>
     <resources>
-        <systemColor name="systemGray2Color">
-            <color red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <image name="favorite_button" width="56" height="54"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/FamousQuoteGeneratorForJojoApp/QuotesData.swift
+++ b/FamousQuoteGeneratorForJojoApp/QuotesData.swift
@@ -95,6 +95,75 @@ struct QuotesData {
     ]
     
     static let quote2 = [
+        Quote(quote: "師範代……\nあんたのしごきに対して\n礼をいうぜ……\nグラッツェ!ロギンス!",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "ハッピー\nうれピー\nよろピくねぇ〜",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "生き残るためには\n手段は選ばないもんネーー\nボクちゃん………\nルンルン",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "この勝負…\nついてるネ\nのってるネ",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "またまた\nやらせていただき\nましたァン!",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "オー!\nノーッ\nおれの嫌いな言葉は\n一番が「努力」で\n二番目が「ガンバル」\nなんだぜーッ",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "逃げるんだよォォォーーーーッ",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "そうさ!\nワムウ!\n戦いは　戦いで別\nシーザーの死の\n悲しみは悲しみで別……\nおれも　なぜか\nあんたに対して\n敬意をはらいたく\nなったのさ………",
+              characterName: "ジョセフ・ジョースター"),
+        Quote(quote: "タコス",
+              characterName: "ドイツ軍人"),
+        Quote(quote: "ウィン\nウィン\nウィン\nウィン\nウィン",
+              characterName: "カーズ"),
+        Quote(quote: "ワムウ!\nやつは戦闘者として\nあまりにも純粋すぎた!\nそれが弱さに\nつながったのだ!!",
+              characterName: "カーズ"),
+        Quote(quote: "勝てばよかろうなのだァァァァッ!!",
+              characterName: "カーズ"),
+        Quote(quote: "しかし\nその無惨なる姿!\n美しいぞ!",
+              characterName: "カーズ"),
+        Quote(quote: "先生も知るように\nおれの決闘の問題だ!\nツェペリ一族の\n問題なのです",
+              characterName: "シーザー・A・ツェペリ"),
+        Quote(quote: "おれが最後に\nみせるのは\n代代受け継いだ\n未来にたくす\nツェペリ魂だ!\n人間の魂だ!",
+              characterName: "シーザー・A・ツェペリ"),
+        Quote(quote: "老いた今!\nなにものをも\n超えた生き物と\nなりたいと願う!",
+              characterName: "ストレイツォ"),
+        Quote(quote: "HEEEEYYYY\nあアアァんまり\nだアアアア",
+              characterName: "エシディシ"),
+        Quote(quote: "や…やつは「神」に\nなったんだ…!\n我われ…人間は\nか…「神」にだけは\n勝てない!\n服従しかないんだ!",
+              characterName: "シュトロハイム"),
+        Quote(quote: "それで\nおれの脚を\n断て!",
+              characterName: "シュトロハイム"),
+        Quote(quote: "そして　死にたいと思っても死ねないので|nーそのうちカーズは　考えるのをやめた。",
+              characterName: "ナレーション"),
+        Quote(quote: "おれの前で\n決闘を侮辱するな!\nJOJO!",
+              characterName: "ワムウ"),
+        Quote(quote: "おれにとって\n強い戦士こそ真理………\n尊敬する者!!\nシャボン玉のように\n華麗ではかなき男よ",
+              characterName: "ワムウ"),
+        Quote(quote: "人間の寿命は\nどうせ短い\n死にいそぐ\n必要もなかろう",
+              characterName: "ワムウ"),
+    ]
+    
+    static let quote3 = [
+        Quote(quote: "", characterName: "")
+    ]
+    
+    static let quote4 = [
+        Quote(quote: "", characterName: "")
+    ]
+    
+    static let quote5 = [
+        Quote(quote: "", characterName: "")
+    ]
+    
+    static let quote6 = [
+        Quote(quote: "", characterName: "")
+    ]
+    
+    static let quote7 = [
+        Quote(quote: "", characterName: "")
+    ]
+    
+    static let quote8 = [
         Quote(quote: "", characterName: "")
     ]
 }


### PR DESCRIPTION
## やったこと
* 1部のコードとUIを他の部にコピペ
* xibファイルに元々あったViewを削除しコピペしたViewをOutlet接続
* それぞれ部ごとにLabelとButtonをOutlet接続
* 部ごとの名言とキャラクター名が表示されるようコードを修正
* 全ての部のタイトルLabelの制約を変更

| 2部画面 | 3部画面 |
| --- | --- |
|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/81965849-24ea-464a-ba95-ca3b9b60935e">|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/78cd32e5-0053-4173-8c22-f8f0f64fe1bc" >|

| 4部画面 | 5部画面 |
| --- | --- |
|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/876b5c66-a96c-49d2-add8-7b2dde2ab255">|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/ff478aaf-5016-4937-8b1c-b526eec05b59">|

| 6部画面 | 7部画面 |
| --- | --- |
|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/608cfefc-df5e-4c9f-8b99-f0ad2df342f8">|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/5397aa16-b216-48ae-aade-f2afbc4041fb">|

| 8部画面 |
| --- |
|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/07430e6d-b2eb-459d-8a61-ce72cacd001c">|


## 動作確認
- [x] それぞれの部へ遷移できることを確認した
- [x] 部ごとのグラデーション背景を表示できることを確認した
- [x] 全ての名言生成画面を統一してUIを配置できていることを確認した