### PR TITLE
登録・取得処理の実装

### DIFF
--- a/FamousQuoteGeneratorForJojoApp.xcodeproj/project.pbxproj
+++ b/FamousQuoteGeneratorForJojoApp.xcodeproj/project.pbxproj
@@ -7,7 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		35E119151CAE5E9D7F7408A4 /* Pods_FamousQuoteGeneratorForJojoApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AEC75793FDAF930302664D7 /* Pods_FamousQuoteGeneratorForJojoApp.framework */; };
 		8B6A394B2C060A150064959E /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8B6A394A2C060A150064959E /* HomeViewController.xib */; };
+		AF3C39602C1C7BAC0040A2CA /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3C395F2C1C7BAC0040A2CA /* RealmManager.swift */; };
+		AF6A4B5B2C1C2C72003FB188 /* QuoteDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6A4B5A2C1C2C72003FB188 /* QuoteDataModel.swift */; };
 		AF7081FB2C19CAA6003B7BBB /* FavoriteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7081F92C19CAA6003B7BBB /* FavoriteTableViewCell.swift */; };
 		AF7081FC2C19CAA6003B7BBB /* FavoriteTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AF7081FA2C19CAA6003B7BBB /* FavoriteTableViewCell.xib */; };
 		AF7081FE2C19DEF4003B7BBB /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7081FD2C19DEF4003B7BBB /* FavoriteHeaderView.swift */; };
@@ -42,7 +45,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7AEC75793FDAF930302664D7 /* Pods_FamousQuoteGeneratorForJojoApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FamousQuoteGeneratorForJojoApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B6A394A2C060A150064959E /* HomeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeViewController.xib; sourceTree = "<group>"; };
+		9714DE312629FD796F0E4875 /* Pods-FamousQuoteGeneratorForJojoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FamousQuoteGeneratorForJojoApp.debug.xcconfig"; path = "Target Support Files/Pods-FamousQuoteGeneratorForJojoApp/Pods-FamousQuoteGeneratorForJojoApp.debug.xcconfig"; sourceTree = "<group>"; };
+		AD102EAD9CA9C79DFC5EA314 /* Pods-FamousQuoteGeneratorForJojoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FamousQuoteGeneratorForJojoApp.release.xcconfig"; path = "Target Support Files/Pods-FamousQuoteGeneratorForJojoApp/Pods-FamousQuoteGeneratorForJojoApp.release.xcconfig"; sourceTree = "<group>"; };
+		AF3C395F2C1C7BAC0040A2CA /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
+		AF6A4B5A2C1C2C72003FB188 /* QuoteDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteDataModel.swift; sourceTree = "<group>"; };
 		AF7081F92C19CAA6003B7BBB /* FavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteTableViewCell.swift; sourceTree = "<group>"; };
 		AF7081FA2C19CAA6003B7BBB /* FavoriteTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FavoriteTableViewCell.xib; sourceTree = "<group>"; };
 		AF7081FD2C19DEF4003B7BBB /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
@@ -83,12 +91,21 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				35E119151CAE5E9D7F7408A4 /* Pods_FamousQuoteGeneratorForJojoApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		02FA89CEB8187796B1A12A4C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7AEC75793FDAF930302664D7 /* Pods_FamousQuoteGeneratorForJojoApp.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		8B6A394C2C0613C70064959E /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -118,6 +135,8 @@
 			children = (
 				AFC3B9E62BF112C8005FCD37 /* FamousQuoteGeneratorForJojoApp */,
 				AFC3B9E52BF112C8005FCD37 /* Products */,
+				F1571CFD593961D210E55A88 /* Pods */,
+				02FA89CEB8187796B1A12A4C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -157,8 +176,19 @@
 				AF7081F42C18AAC3003B7BBB /* Favorite */,
 				AFAA04842C02F03C00AD9F74 /* QuotesData.swift */,
 				AFC33D812C0A1D13003B0E82 /* UIColorExtension.swift */,
+				AF6A4B5A2C1C2C72003FB188 /* QuoteDataModel.swift */,
+				AF3C395F2C1C7BAC0040A2CA /* RealmManager.swift */,
 			);
 			path = FamousQuoteGeneratorForJojoApp;
+			sourceTree = "<group>";
+		};
+		F1571CFD593961D210E55A88 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9714DE312629FD796F0E4875 /* Pods-FamousQuoteGeneratorForJojoApp.debug.xcconfig */,
+				AD102EAD9CA9C79DFC5EA314 /* Pods-FamousQuoteGeneratorForJojoApp.release.xcconfig */,
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -168,9 +198,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AFC3B9F82BF112CB005FCD37 /* Build configuration list for PBXNativeTarget "FamousQuoteGeneratorForJojoApp" */;
 			buildPhases = (
+				7B802A791B41B95FC128ED07 /* [CP] Check Pods Manifest.lock */,
 				AFC3B9E02BF112C8005FCD37 /* Sources */,
 				AFC3B9E12BF112C8005FCD37 /* Frameworks */,
 				AFC3B9E22BF112C8005FCD37 /* Resources */,
+				F5106115F5C861F8FD04F1EC /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -239,6 +271,48 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		7B802A791B41B95FC128ED07 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-FamousQuoteGeneratorForJojoApp-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F5106115F5C861F8FD04F1EC /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-FamousQuoteGeneratorForJojoApp/Pods-FamousQuoteGeneratorForJojoApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-FamousQuoteGeneratorForJojoApp/Pods-FamousQuoteGeneratorForJojoApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FamousQuoteGeneratorForJojoApp/Pods-FamousQuoteGeneratorForJojoApp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		AFC3B9E02BF112C8005FCD37 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -254,6 +328,8 @@
 				AF8657E32BFCBE750025C341 /* Quote6ViewController.swift in Sources */,
 				AF8657D32BFCBE0F0025C341 /* Quote2ViewController.swift in Sources */,
 				AF8657EB2BFCBEAA0025C341 /* Quote8ViewController.swift in Sources */,
+				AF6A4B5B2C1C2C72003FB188 /* QuoteDataModel.swift in Sources */,
+				AF3C39602C1C7BAC0040A2CA /* RealmManager.swift in Sources */,
 				AF7081FB2C19CAA6003B7BBB /* FavoriteTableViewCell.swift in Sources */,
 				AFC3B9E82BF112C8005FCD37 /* AppDelegate.swift in Sources */,
 				AFC3B9EA2BF112C8005FCD37 /* SceneDelegate.swift in Sources */,
@@ -315,7 +391,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -378,7 +454,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -399,6 +475,7 @@
 		};
 		AFC3B9F92BF112CB005FCD37 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9714DE312629FD796F0E4875 /* Pods-FamousQuoteGeneratorForJojoApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -426,6 +503,7 @@
 		};
 		AFC3B9FA2BF112CB005FCD37 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AD102EAD9CA9C79DFC5EA314 /* Pods-FamousQuoteGeneratorForJojoApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/FamousQuoteGeneratorForJojoApp.xcodeproj/xcuserdata/nishiikensuke.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/FamousQuoteGeneratorForJojoApp.xcodeproj/xcuserdata/nishiikensuke.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>FamousQuoteGeneratorForJojoApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>5</integer>
 		</dict>
 	</dict>
 </dict>

--- a/FamousQuoteGeneratorForJojoApp/Favorite/FavoriteTableViewCell.xib
+++ b/FamousQuoteGeneratorForJojoApp/Favorite/FavoriteTableViewCell.xib
@@ -72,6 +72,11 @@
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="characterLabel" destination="VWk-ww-UpW" id="12z-tJ-jUy"/>
+                <outlet property="partLabel" destination="Iyb-at-piy" id="z3B-qJ-58O"/>
+                <outlet property="quoteLabel" destination="1zA-ri-LmI" id="Hqn-gH-nFs"/>
+            </connections>
             <point key="canvasLocation" x="189" y="75"/>
         </tableViewCell>
     </objects>

--- a/FamousQuoteGeneratorForJojoApp/FavoriteViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/FavoriteViewController.swift
@@ -6,9 +6,21 @@
 //
 
 import UIKit
+import RealmSwift
 
 /// お気に入り画面
 class FavoriteViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
+    /// 取得したデータの格納先
+    var groupedQuotes = Array(repeating: [QuoteDataModel](), count: 8)
+    
+    /// セクションヘッダー表示用の配列
+    var displayedSections: [Int] = []
     
     // MARK: - Outlets
     
@@ -19,6 +31,7 @@ class FavoriteViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTableView()
+        fetchData()
         
         navigationItem.title = "お気に入り"
     }
@@ -28,10 +41,24 @@ class FavoriteViewController: UIViewController {
     private func configureTableView() {
         tableView.dataSource = self
         tableView.delegate = self
-
+        
         // カスタムセル
         let nib = UINib(nibName: "FavoriteTableViewCell", bundle: nil)
         tableView.register(nib, forCellReuseIdentifier: "Cell")
+    }
+    
+    /// データを取得
+    private func fetchData() {
+        let results = realmManager.getObjects(QuoteDataModel.self)
+        // 部数に合ったセクションナンバーで二次元配列に格納
+        for quote in results {
+            let sectionIndex = quote.part - 1
+            if sectionIndex >= 0 && sectionIndex < groupedQuotes.count {
+                groupedQuotes[sectionIndex].append(quote)
+            }
+            self.displayedSections.append(sectionIndex)
+        }
+        tableView.reloadData()
     }
 }
 
@@ -40,19 +67,69 @@ class FavoriteViewController: UIViewController {
 extension FavoriteViewController: UITableViewDataSource {
     /// セクションの数
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 3
+        return 8
     }
     
     /// セクションヘッダービューを設定
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = FavoriteHeaderView()
-        headerView.configure(number: 1, backgroundColor: .red)
+        switch section {
+        case 0:
+            if displayedSections.contains(0) {
+                headerView.configure(number: 1, backgroundColor: UIColor(hex: "#08CF79"))
+            } else {
+                headerView.isHidden = true
+            }
+        case 1:
+            if displayedSections.contains(1) {
+                headerView.configure(number: 2, backgroundColor: UIColor(hex: "#57FF03"))
+            } else {
+                headerView.isHidden = true
+            }
+        case 2:
+            if displayedSections.contains(2) {
+                headerView.configure(number: 3, backgroundColor: UIColor(hex: "#0080FF"))
+            } else {
+                headerView.isHidden = true
+            }
+        case 3:
+            if displayedSections.contains(3) {
+                headerView.configure(number: 4, backgroundColor: UIColor(hex: "#B266FF"))
+            } else {
+                headerView.isHidden = true
+            }
+        case 4:
+            if displayedSections.contains(4) {
+                headerView.configure(number: 5, backgroundColor: UIColor(hex: "#FFFF99"))
+            } else {
+                headerView.isHidden = true
+            }
+        case 5:
+            if displayedSections.contains(5) {
+                headerView.configure(number: 6, backgroundColor: UIColor(hex: "#87EBFF"))
+            } else {
+                headerView.isHidden = true
+            }
+        case 6:
+            if displayedSections.contains(6) {
+                headerView.configure(number: 7, backgroundColor: UIColor(hex: "#FFCC99"))
+            } else {
+                headerView.isHidden = true
+            }
+        case 7:
+            if displayedSections.contains(7) {
+                headerView.configure(number: 8, backgroundColor: UIColor(hex: "#E6E6E6"))
+            } else {
+                headerView.isHidden = true
+            }
+        default:
+            break
+        }
         return headerView
-        
     }
     /// データの数（＝セルの数）を返すメソッド
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 3
+        return groupedQuotes[section].count
     }
     
     /// 各セルの内容を返すメソッド
@@ -60,6 +137,10 @@ extension FavoriteViewController: UITableViewDataSource {
         // 再利用可能な cell を得る
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)as! FavoriteTableViewCell
         // ここにセルに渡す処理を書く
+        let quote = groupedQuotes[indexPath.section][indexPath.row]
+        cell.configure(quote: quote.quote,
+                       part: "\(quote.part)部",
+                       character: quote.characterName)
         return cell
     }
 }

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 1部名言生成画面
 class Quote1ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -30,18 +38,52 @@ class Quote1ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote1.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 1
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="cNC-I9-HUU"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="cNC-I9-HUU"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lri-np-bns">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="nNF-aa-7uU"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="nNF-aa-7uU"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
@@ -30,10 +30,10 @@ class Quote2ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote2.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="W2m-Az-Dwk"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="W2m-Az-Dwk"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="evj-nM-vOn">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="DFl-1A-dmW"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="DFl-1A-dmW"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
@@ -30,10 +30,10 @@ class Quote3ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote3.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="RbV-fZ-Rgb"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="RbV-fZ-Rgb"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r99-Kg-blS">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="hZD-4R-Ph4"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="hZD-4R-Ph4"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
@@ -30,10 +30,10 @@ class Quote4ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote4.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="UBY-J0-xYz"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="UBY-J0-xYz"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M86-dW-hKz">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="2Je-9I-at8"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="2Je-9I-at8"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
@@ -30,10 +30,10 @@ class Quote5ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote5.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="2hn-bW-RYo"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="2hn-bW-RYo"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Gc-S7-TEV">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="zPs-Yt-Tuj"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="zPs-Yt-Tuj"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
@@ -30,10 +30,10 @@ class Quote6ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote6.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="APN-0X-ys2"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="APN-0X-ys2"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sv9-aJ-lRr">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="p1q-W5-KMQ"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="p1q-W5-KMQ"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
@@ -30,10 +30,10 @@ class Quote7ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote7.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="4js-9d-Qum"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="4js-9d-Qum"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="azN-ze-Gng">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="Cyd-qi-INO"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="Cyd-qi-INO"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
@@ -30,10 +30,10 @@ class Quote8ViewController: UIViewController {
     
     // MARK: - IBActions
     
-    @IBAction private func favoriteButton(_ sender: Any) {
+    @IBAction private func didTapFavoriteButton(_ sender: Any) {
     }
     
-    @IBAction private func generateButton(_ sender: Any) {
+    @IBAction private func didTapGenerateButton(_ sender: Any) {
         //ランダムに名言を設定
         if let randomQuote = QuotesData.quote8.randomElement() {
             quoteLabel.text = randomQuote.quote

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.xib
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.xib
@@ -81,7 +81,7 @@
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" image="favorite_button"/>
                     <connections>
-                        <action selector="favoriteButton:" destination="-1" eventType="touchUpInside" id="uCt-qt-8aS"/>
+                        <action selector="didTapFavoriteButton:" destination="-1" eventType="touchUpInside" id="uCt-qt-8aS"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MBB-Qq-Ie3">
@@ -101,7 +101,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="generateButton:" destination="-1" eventType="touchUpInside" id="udO-wT-u45"/>
+                        <action selector="didTapGenerateButton:" destination="-1" eventType="touchUpInside" id="udO-wT-u45"/>
                     </connections>
                 </button>
             </subviews>

--- a/FamousQuoteGeneratorForJojoApp/QuoteDataModel.swift
+++ b/FamousQuoteGeneratorForJojoApp/QuoteDataModel.swift
@@ -1,0 +1,15 @@
+//
+//  QuoteDataModel.swift
+//  FamousQuoteGeneratorForJojoApp
+//
+//  Created by にしいけんすけ on 2024/06/14.
+//
+
+import RealmSwift
+
+final class QuoteDataModel: Object {
+    @Persisted var id: String = UUID().uuidString // データを一意に識別するための識別子
+    @Persisted var quote: String = ""
+    @Persisted var part: Int = 0
+    @Persisted var characterName: String = ""
+}

--- a/FamousQuoteGeneratorForJojoApp/RealmManager.swift
+++ b/FamousQuoteGeneratorForJojoApp/RealmManager.swift
@@ -1,0 +1,85 @@
+//
+//  RealmManager.swift
+//  FamousQuoteGeneratorForJojoApp
+//
+//  Created by にしいけんすけ on 2024/06/14.
+//
+
+import RealmSwift
+
+/// Realmの管理クラス
+class RealmManager {
+    
+    // MARK: - Type Properties
+    
+    /// シングルトンインスタンス
+    static let shared = RealmManager()
+    
+    // MARK: - Properties
+    
+    /// プライベートなRealmインスタンス
+    private let realm: Realm
+    
+    // MARK: - Initializers
+    
+    /// プライベート初期化子
+    private init() {
+        // Realmのデフォルトコンフィギュレーションを使用してインスタンスを作成
+        do {
+            realm = try Realm()
+        } catch {
+            fatalError("Failed to instantiate Realm: \(error)")
+        }
+    }
+    
+    // MARK: - Other Methods
+    
+    /// Create: オブジェクトをRealmに追加
+    func add<T: Object>(_ object: T,
+                        onSuccess: (() -> Void)? = nil,
+                        onFailure: ((Error) -> Void)? = nil) {
+        do {
+            try realm.write {
+                realm.add(object)
+            }
+            onSuccess?()
+        } catch {
+            onFailure?(error)
+        }
+    }
+    
+    /// Read: オブジェクトを取得
+    func getObjects<T: Object>(_ type: T.Type) -> Results<T> {
+        return realm.objects(type)
+    }
+    
+    /// Update: オブジェクトを更新
+    func update(onSuccess: (() -> Void)? = nil,
+                onFailure: ((Error) -> Void)? = nil,
+                _ block: () -> Void) {
+        do {
+            try realm.write {
+                block()
+            }
+            onSuccess?()
+        } catch {
+            onFailure?(error)
+        }
+    }
+    
+    /// Delete: オブジェクトを削除
+    func delete<T: Object>(_ object: T,
+                           onSuccess: (() -> Void)? = nil,
+                           onFailure: ((Error) -> Void)? = nil) {
+        do {
+            try realm.write {
+                realm.delete(object)
+            }
+            onSuccess?()
+        } catch {
+            onFailure?(error)
+        }
+    }
+}
+
+


### PR DESCRIPTION
## やったこと
* RealmSwiftをインストール
* 〇〇の処理を実装
* Realmのシングルトンクラスを作成し、コードを記述
* 登録処理を実装(Quote1ViewControllerのみ)
* 取得処理を実装(FaboriteViewController)

## 画像
| 1部名言生成画面 | お気に入り画面 |
| --- | --- |
|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/57768204-ea22-4748-a16a-ab64680c9e42">|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/41bf84d2-b123-453f-8b49-cab3fd097a65">|


## 動作確認
- [x] 『お気に入りボタン』をタップしてお気に入りに登録できることを確認した
- [x] お気に入りに登録された名言、キャラクター名、部数をお気に入り画面で表示できることを確認した
- [x] ヘッダービューが表示できることを確認した