### PR TITLE
2部〜8部の保存処理を追加

### DIFF
--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
@@ -14,7 +14,8 @@ class Quote1ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote1ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote1ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
@@ -47,7 +47,7 @@ class Quote1ViewController: UIViewController {
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote1.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
@@ -14,7 +14,8 @@ class Quote2ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote2ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote2ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 2部名言生成画面
 class Quote2ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -31,17 +39,51 @@ class Quote2ViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote2.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 2
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 3部名言生成画面
 class Quote3ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -31,17 +39,51 @@ class Quote3ViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote3.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 3
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
@@ -14,7 +14,8 @@ class Quote3ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote3ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote3ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 4部名言生成画面
 class Quote4ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -31,17 +39,51 @@ class Quote4ViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote4.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 4
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
@@ -14,7 +14,8 @@ class Quote4ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote4ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote4ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
@@ -14,7 +14,8 @@ class Quote5ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote5ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote5ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 5部名言生成画面
 class Quote5ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -31,17 +39,51 @@ class Quote5ViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote5.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 5
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 6部名言生成画面
 class Quote6ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -31,17 +39,51 @@ class Quote6ViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote6.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 6
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
@@ -14,7 +14,8 @@ class Quote6ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote6ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote6ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
@@ -14,7 +14,8 @@ class Quote7ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote7ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote7ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 7部名言生成画面
 class Quote7ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -31,17 +39,51 @@ class Quote7ViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote7.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 7
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 /// 8部名言生成画面
 class Quote8ViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var quote: String = ""
+    var characterName: String = ""
+    
+    /// RealmManagerのシングルトンインスタンスを取得
+    let realmManager = RealmManager.shared
+    
     // MARK: - IBOutlets
     
     /// 名言を表示させるラベル
@@ -31,17 +39,51 @@ class Quote8ViewController: UIViewController {
     // MARK: - IBActions
     
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
+        if quote.isEmpty, characterName.isEmpty {
+            showAlert(title: "名言を生成してください")
+        } else {
+            saveData()
+        }
     }
     
     @IBAction private func didTapGenerateButton(_ sender: Any) {
-        //ランダムに名言を設定
+        // ランダムに名言を設定
         if let randomQuote = QuotesData.quote8.randomElement() {
             quoteLabel.text = randomQuote.quote
             characterLabel.text = randomQuote.characterName
+            quote = randomQuote.quote
+            characterName = randomQuote.characterName
         }
     }
     
     // MARK: - Other Methods
+    
+    /// データを保存する
+    private func saveData() {
+        let dataModel = QuoteDataModel()
+        dataModel.quote = quote
+        dataModel.part = 8
+        dataModel.characterName = characterName
+        
+        realmManager.add(dataModel, onSuccess: {
+            // 成功時の処理
+            print("Object added successfully")
+            self.showAlert(title: "お気に入りに保存しました")
+        }, onFailure: { error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            self.showAlert(title: "エラーが発生しました")
+        })
+    }
+    
+    /// アラートを表示
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title,
+                                      message: "",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        self.present(alert, animated: true, completion: nil)
+    }
     
     /// UIViewにグラデーションを追加する関数
     private func configureGradientView(view: UIView) {

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
@@ -14,7 +14,8 @@ class Quote8ViewController: UIViewController {
     
     var quote: String = ""
     var characterName: String = ""
-    
+    /// 保存済みかどうか
+    var isSaved: Bool = false
     /// RealmManagerのシングルトンインスタンスを取得
     let realmManager = RealmManager.shared
     
@@ -41,8 +42,11 @@ class Quote8ViewController: UIViewController {
     @IBAction private func didTapFavoriteButton(_ sender: Any) {
         if quote.isEmpty, characterName.isEmpty {
             showAlert(title: "名言を生成してください")
+        } else if isSaved {
+            showAlert(title: "新しい名言を生成してください")
         } else {
             saveData()
+            isSaved = true
         }
     }
     
@@ -54,6 +58,7 @@ class Quote8ViewController: UIViewController {
             quote = randomQuote.quote
             characterName = randomQuote.characterName
         }
+        isSaved = false
     }
     
     // MARK: - Other Methods

--- a/FamousQuoteGeneratorForJojoApp/QuotesData.swift
+++ b/FamousQuoteGeneratorForJojoApp/QuotesData.swift
@@ -268,7 +268,7 @@ struct QuotesData {
         Quote(quote: "人間の魂というものは\n実に不思議だ\n「敗北」する時!\n自分の「敗北」を\n自分で認めた瞬間\n魂のエネルギーは\n限りなく0に近くなる\n………",
               characterName: "テレンス・T・ダービー"),
         Quote(quote: "触れてはいけない\n物というのは\n触れてしまいたく\nなるものね",
-              characterName: "マライや"),
+              characterName: "マライヤ"),
         Quote(quote: "『死ぬのはこわくない\nしかしあの人に　見捨てられ\n殺されるのだけはいやだ』\n悪には悪の救世主が\n必要なんだよ\nフフフフ",
               characterName: "ンドゥール"),
         Quote(quote: "チュミミ〜ン",


### PR DESCRIPTION
## やったこと
* 2部〜8部それぞれに保存処理を実装

## 画像
| お気に入り画面 | お気に入り画面 |
| --- | --- |
|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/79216cec-207f-473b-8643-e97d193cb553">|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/12575b37-6a9b-4944-b279-d99c37f0d34c">|

## 動作確認
- [x] 2部〜8部それぞれの名言をお気に入りボタンを押して、お気に入り画面に保存できることを確認した
- [x] 2部〜8部のお気に入りに追加した名言、部数、キャラクター名が表示できることを確認した
- [x] 2部〜8部のHeaderViewが表示できることを確認した
