### PR TITLE
iPhone8Plusで正常にレイアウトが反映されるようにコードを修正

### DIFF
--- a/FamousQuoteGeneratorForJojoApp.xcodeproj/project.pbxproj
+++ b/FamousQuoteGeneratorForJojoApp.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -520,6 +521,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote1ViewController.swift
@@ -34,6 +34,10 @@ class Quote1ViewController: UIViewController {
         if QuotesData.quote1.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     

--- a/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote2ViewController.swift
@@ -34,6 +34,10 @@ class Quote2ViewController: UIViewController {
         if QuotesData.quote2.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     

--- a/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote3ViewController.swift
@@ -34,6 +34,10 @@ class Quote3ViewController: UIViewController {
         if QuotesData.quote3.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     

--- a/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote4ViewController.swift
@@ -34,6 +34,10 @@ class Quote4ViewController: UIViewController {
         if QuotesData.quote4.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     

--- a/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote5ViewController.swift
@@ -34,6 +34,10 @@ class Quote5ViewController: UIViewController {
         if QuotesData.quote5.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     

--- a/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote6ViewController.swift
@@ -34,6 +34,10 @@ class Quote6ViewController: UIViewController {
         if QuotesData.quote6.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     

--- a/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote7ViewController.swift
@@ -34,6 +34,10 @@ class Quote7ViewController: UIViewController {
         if QuotesData.quote7.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     

--- a/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
+++ b/FamousQuoteGeneratorForJojoApp/Quote8ViewController.swift
@@ -34,6 +34,10 @@ class Quote8ViewController: UIViewController {
         if QuotesData.quote8.first != nil {
             quoteLabel.text = "名言生成ッ!!をタップ"
             characterLabel.text = ""}
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configureGradientView(view: self.view)
     }
     


### PR DESCRIPTION
## やったこと
* iPhone8Plusで背景が正常に表示されるようにコードを修正

## 画像

| 名言生成画面 | 名言生成画面 |
| --- | --- |
|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/539b215e-141b-4890-8061-dbbbf2e90dea">|<img width="240" src="https://github.com/kensuke-0n0/FamousQuoteGeneratorForJojo/assets/163435814/945ed8ac-fae2-4be4-a3a3-966615271831">|

## 動作確認
- [x] それぞれの名言生成画面で正常に背景が表示されることを確認した